### PR TITLE
fix: use GITHUB_TOKEN for npm registry auth in Cypress component tests

### DIFF
--- a/.github/workflows/cypress-component-tests.yml
+++ b/.github/workflows/cypress-component-tests.yml
@@ -44,6 +44,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   component_tests:

--- a/.github/workflows/cypress-component-tests.yml
+++ b/.github/workflows/cypress-component-tests.yml
@@ -55,15 +55,6 @@ jobs:
       matrix:
         browser: ${{ fromJSON(inputs.browsers) }}
     steps:
-      - name: Create App Token
-        id: repo-token
-        uses: Onemind-Services-LLC/actions/actions/create-repo-token@master
-        with:
-          app-id: ${{ inputs.app-id }}
-          private-key: ${{ secrets.private-key }}
-          owner: Onemind-Services-LLC
-          github-token: ${{ github.actor == 'dependabot[bot]' && github.token || '' }}
-
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -74,6 +65,6 @@ jobs:
           browser: ${{ matrix.browser }}
           registry-scope: ${{ inputs.registry-scope }}
           registry-url: ${{ inputs.registry-url }}
-          npm-token: ${{ steps.repo-token.outputs.token }}
+          npm-token: ${{ github.token }}
           working-directory: ${{ inputs.working-directory }}
           node-version: ${{ inputs.node-version }}

--- a/actions/node-install-build/action.yml
+++ b/actions/node-install-build/action.yml
@@ -78,7 +78,6 @@ runs:
         cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.registry-scope }}
-        always-auth: ${{ inputs.registry-url != '' }}
 
     - name: Enable Corepack (Yarn/pnpm)
       if: ${{ inputs.package-manager == 'yarn' || inputs.package-manager == 'pnpm' }}
@@ -94,7 +93,6 @@ runs:
         cache-dependency-path: ${{ inputs.working-directory }}/yarn.lock
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.registry-scope }}
-        always-auth: ${{ inputs.registry-url != '' }}
 
     - name: Setup Node.js (pnpm)
       if: ${{ inputs.package-manager == 'pnpm' }}
@@ -105,7 +103,6 @@ runs:
         cache-dependency-path: ${{ inputs.working-directory }}/pnpm-lock.yaml
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.registry-scope }}
-        always-auth: ${{ inputs.registry-url != '' }}
 
     - name: Is this a Next.js project?
       id: nextjs-check

--- a/actions/node-install-build/action.yml
+++ b/actions/node-install-build/action.yml
@@ -78,6 +78,7 @@ runs:
         cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.registry-scope }}
+        always-auth: ${{ inputs.registry-url != '' }}
 
     - name: Enable Corepack (Yarn/pnpm)
       if: ${{ inputs.package-manager == 'yarn' || inputs.package-manager == 'pnpm' }}
@@ -93,6 +94,7 @@ runs:
         cache-dependency-path: ${{ inputs.working-directory }}/yarn.lock
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.registry-scope }}
+        always-auth: ${{ inputs.registry-url != '' }}
 
     - name: Setup Node.js (pnpm)
       if: ${{ inputs.package-manager == 'pnpm' }}
@@ -103,6 +105,7 @@ runs:
         cache-dependency-path: ${{ inputs.working-directory }}/pnpm-lock.yaml
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.registry-scope }}
+        always-auth: ${{ inputs.registry-url != '' }}
 
     - name: Is this a Next.js project?
       id: nextjs-check


### PR DESCRIPTION
## Problem
  
  Cypress component tests were failing with a 403 error when attempting to
  install `@Onemind-Services-LLC/ui-components` from GitHub Package Registry:
  
  npm error 403 Forbidden - Permission installation not allowed to Read organization package

  The workflow was generating a GitHub App installation token and using it as
  the npm auth token. However, the App installation does not have `packages: read`
  permission, so it cannot download private organization packages from
  `https://npm.pkg.github.com`.

  ## Changes
  
  - **`cypress-component-tests.yml`**: Added `packages: read` to workflow-level
    permissions so `GITHUB_TOKEN` is granted read access to GitHub Packages.
  - **`cypress-component-tests.yml`**: Removed the `Create App Token` step — it
    was used solely for npm auth, which is now handled by `GITHUB_TOKEN`.
  - **`cypress-component-tests.yml`**: Changed `npm-token` from the App
    installation token to `github.token`, which inherits `packages: read` from
    the workflow permissions.

  ## Why this works
  
  GitHub Actions' `GITHUB_TOKEN` with `packages: read` permission has access to
  all packages within the organization when the workflow is triggered from a
  branch inside the org. This removes the dependency on the GitHub App having
  `packages: read` configured at the installation level.