### PR TITLE
fix: resolve Node.js 24 cache crash in component tests

### DIFF
--- a/actions/cypress-test/action.yml
+++ b/actions/cypress-test/action.yml
@@ -50,16 +50,29 @@ runs:
       with:
         working-directory: ${{ inputs.working-directory }}
 
-    - name: Setup Node.js
+    - name: Setup Node.js and install dependencies
       uses: Onemind-Services-LLC/actions/actions/node-install-build@master
       with:
         package-manager: ${{ steps.pm.outputs.package-manager }}
         node-version: ${{ inputs.node-version }}
-        install: false
+        install: true
         build: false
         registry-url: ${{ inputs.registry-url }}
         registry-scope: ${{ inputs.registry-scope }}
         npm-token: ${{ inputs.npm-token }}
+
+    - name: Cache Cypress binary
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/Cypress
+        key: ${{ runner.os }}-cypress-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-cypress-
+
+    - name: Install Cypress binary
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: npx cypress install
 
     - name: Install Dependencies
       shell: bash
@@ -150,7 +163,7 @@ runs:
       uses: cypress-io/github-action@7ef72e250a9e564efb4ed4c2433971ada4cc38b4 # v6.10.4
       with:
         component: ${{ inputs.component }}
-        install: true
+        install: false
         browser: ${{ inputs.browser == 'chrome' && 'chrome-for-testing' || inputs.browser }}
         build: ${{ inputs.build }}
         start: ${{ inputs.start }}

--- a/actions/node-install-build/action.yml
+++ b/actions/node-install-build/action.yml
@@ -62,18 +62,17 @@ runs:
     # Yarn/pnpm need a Node runtime before Corepack can be enabled.
     - name: Setup Node.js (bootstrap for Yarn/pnpm)
       if: ${{ inputs.package-manager == 'yarn' || inputs.package-manager == 'pnpm' }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
 
     - name: Setup Node.js (npm)
       if: ${{ inputs.package-manager == 'npm' }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.registry-scope }}
-        always-auth: ${{ inputs.registry-url != '' }}
 
     - name: Cache npm dependencies
       if: ${{ inputs.package-manager == 'npm' }}
@@ -91,12 +90,11 @@ runs:
 
     - name: Setup Node.js (Yarn)
       if: ${{ inputs.package-manager == 'yarn' }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.registry-scope }}
-        always-auth: ${{ inputs.registry-url != '' }}
 
     - name: Get Yarn cache directory
       if: ${{ inputs.package-manager == 'yarn' }}
@@ -115,12 +113,11 @@ runs:
 
     - name: Setup Node.js (pnpm)
       if: ${{ inputs.package-manager == 'pnpm' }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.registry-scope }}
-        always-auth: ${{ inputs.registry-url != '' }}
 
     - name: Get pnpm store directory
       if: ${{ inputs.package-manager == 'pnpm' }}
@@ -153,7 +150,7 @@ runs:
         echo "Not a Next.js project."
         echo "is-nextjs=false" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       if: ${{ steps.nextjs-check.outputs.is-nextjs == 'true' }}
       with:
         path: |

--- a/actions/node-install-build/action.yml
+++ b/actions/node-install-build/action.yml
@@ -59,26 +59,30 @@ runs:
           exit 1
         fi
 
-    # For Yarn/pnpm, we need a Node runtime available before enabling Corepack,
-    # and Corepack must be enabled before we call setup-node with cache: yarn/pnpm
-    # (setup-node queries the package manager to resolve cache paths).
+    # Yarn/pnpm need a Node runtime before Corepack can be enabled.
     - name: Setup Node.js (bootstrap for Yarn/pnpm)
       if: ${{ inputs.package-manager == 'yarn' || inputs.package-manager == 'pnpm' }}
       uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
-        # No cache in the bootstrap step
 
     - name: Setup Node.js (npm)
       if: ${{ inputs.package-manager == 'npm' }}
       uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
-        cache: npm
-        cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.registry-scope }}
         always-auth: ${{ inputs.registry-url != '' }}
+
+    - name: Cache npm dependencies
+      if: ${{ inputs.package-manager == 'npm' }}
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-npm-
 
     - name: Enable Corepack (Yarn/pnpm)
       if: ${{ inputs.package-manager == 'yarn' || inputs.package-manager == 'pnpm' }}
@@ -90,22 +94,48 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
-        cache: yarn
-        cache-dependency-path: ${{ inputs.working-directory }}/yarn.lock
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.registry-scope }}
         always-auth: ${{ inputs.registry-url != '' }}
+
+    - name: Get Yarn cache directory
+      if: ${{ inputs.package-manager == 'yarn' }}
+      id: yarn-cache-dir
+      shell: bash
+      run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Yarn dependencies
+      if: ${{ inputs.package-manager == 'yarn' }}
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.yarn-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     - name: Setup Node.js (pnpm)
       if: ${{ inputs.package-manager == 'pnpm' }}
       uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
-        cache: pnpm
-        cache-dependency-path: ${{ inputs.working-directory }}/pnpm-lock.yaml
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.registry-scope }}
         always-auth: ${{ inputs.registry-url != '' }}
+
+    - name: Get pnpm store directory
+      if: ${{ inputs.package-manager == 'pnpm' }}
+      id: pnpm-store
+      shell: bash
+      run: echo "dir=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache pnpm dependencies
+      if: ${{ inputs.package-manager == 'pnpm' }}
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.pnpm-store.outputs.dir }}
+        key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-
 
     - name: Is this a Next.js project?
       id: nextjs-check

--- a/actions/npm-install-build/action.yml
+++ b/actions/npm-install-build/action.yml
@@ -52,14 +52,19 @@ runs:
         echo "::warning::Use 'Onemind-Services-LLC/actions/actions/node-install-build' with 'package-manager'."
 
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
-        cache: npm
-        cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.registry-scope }}
-        always-auth: ${{ inputs.registry-url != '' }}
+
+    - name: Cache npm dependencies
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-npm-
 
     - name: Install Dependencies
       if: ${{ inputs.install == 'true' }}


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  Component test runs were crashing with an unhandled `ENOENT` error in the                                                                                                                                                                                                                                         
  post-step cache save phase:                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                    
  Error: ENOENT: no such file or directory, open                                                                                                                                                                                                                                                                    
    '/home/runner/_work/_temp/<uuid>/cache.tzst'                                                                                                                                                                                                                                                                    
  Node.js v24.16.0                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                    
  This is a known Node.js 24 incompatibility in the `@actions/cache` SDK used                                                                                                                                                                                                                                       
  by `actions/cache@v4`. On Node.js 24, `tar` writes `cache.tzst` to the                                                                                                                                                                                                                                            
  current working directory instead of `$RUNNER_TEMP`, so when the SDK tries                                                                                                                                                                                                                                        
  to read it back from the absolute temp path it crashes with ENOENT.                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                    
  Three separate cache operations were triggering this:                                                                                                                                                                                                                                                             
  1. `setup-node`'s built-in `cache: npm/yarn/pnpm` — uses the old `@actions/cache`                                                                                                                                                                                                                                 
     library bundled inside setup-node                                                                                                                                                                                                                                                                              
  2. `actions/cache@v4` in the Next.js cache step                                                                                                                                                                                                                                                                   
  3. `cypress-io/github-action@v7.4.1` (latest) — bundles its own old                                                                                                                                                                                                                                               
     `@actions/cache` SDK, no upstream fix available yet                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                    
  ## Changes                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  **`actions/node-install-build`**                                                                                                                                                                                                                                                                                  
  - Removed `cache: npm/yarn/pnpm` and `cache-dependency-path` from all                                                                                                                                                                                                                                             
    `setup-node` calls — replaced with explicit `actions/cache@v6.1.0` steps                                                                                                                                                                                                                                        
    for each package manager (npm `~/.npm`, yarn cache dir, pnpm store path)                                                                                                                                                                                                                                        
  - Upgraded Next.js cache step from `actions/cache@v4` → `actions/cache@v6.1.0`                                                                                                                                                                                                                                    
  - Pinned `actions/setup-node` to SHA for v6.4.0                                                                                                                                                                                                                                                                   
  - Removed `always-auth` input (dropped in setup-node v6, was causing                                                                                                                                                                                                                                              
    `Unexpected input(s) 'always-auth'` warning on every run)                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                    
  **`actions/npm-install-build`**                                                                                                                                                                                                                                                                                   
  - Same setup-node pin, always-auth removal, and cache fix as above                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                    
  **`actions/cypress-test`**                                                                                                                                                                                                                                                                                        
  - Moved npm install into `node-install-build` (`install: true`) so all                                                                                                                                                                                                                                            
    caching goes through our pinned `actions/cache@v6.1.0`                                                                                                                                                                                                                                                          
  - Added explicit `actions/cache@v6.1.0` step to cache the Cypress binary                                                                                                                                                                                                                                          
    (`~/.cache/Cypress`) independently                                                                                                                                                                                                                                                                              
  - Added `npx cypress install` step to download the binary if cache misses                                                                                                                                                                                                                                         
  - Set `cypress-io/github-action` to `install: false` — skips its broken                                                                                                                                                                                                                                           
    internal cache operations entirely, runs tests against the                                                                                                                                                                                                                                                      
    already-installed binary                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  ## Test plan                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                    
  - [ ] Component tests complete without the `ENOENT cache.tzst` crash                                                                                                                                                                                                                                              
  - [ ] npm cache is restored on subsequent runs (key: `Linux-npm-<lockfile-hash>`)                                                                                                                                                                                                                                 
  - [ ] Cypress binary cache is restored on subsequent runs (key: `Linux-cypress-<lockfile-hash>`)                                                                                                                                                                                                                  
  - [ ] No `Unexpected input(s) 'always-auth'` warning in setup-node step